### PR TITLE
Allow newer sassc for m1 macs compatibility

### DIFF
--- a/sassc-import_once.gemspec
+++ b/sassc-import_once.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sassc", "~> 1.8"
+  spec.add_dependency "sassc", [">= 1.8", "< 3"]
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Newer sassc versions use newer ffi versions,
which are needed for m1 macs.